### PR TITLE
Fix persistent loading spinner in Downloads page

### DIFF
--- a/frontend/src/app/(app)/downloads/page.tsx
+++ b/frontend/src/app/(app)/downloads/page.tsx
@@ -19,6 +19,7 @@ export default function Downloads() {
     downloads, 
     stats, 
     loading, 
+    refreshing,
     error, 
     refetch, 
     performAction, 
@@ -124,10 +125,10 @@ export default function Downloads() {
             variant="outline"
             size="sm"
             onClick={refetch}
-            disabled={loading}
+            disabled={refreshing}
             className="flex items-center gap-2"
           >
-            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+            <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
             Refresh
           </Button>
           <Button 
@@ -206,6 +207,7 @@ export default function Downloads() {
           downloads={downloads}
           stats={stats}
           loading={loading}
+          refreshing={refreshing}
           onCancel={handleCancel}
           onRetry={handleRetry}
           onDelete={handleDelete}

--- a/frontend/src/components/downloads/download-queue.tsx
+++ b/frontend/src/components/downloads/download-queue.tsx
@@ -35,6 +35,7 @@ interface DownloadQueueProps {
   downloads: DownloadJobResponse[];
   stats: DownloadQueueStats;
   loading: boolean;
+  refreshing: boolean;
   onCancel: (jobId: string) => Promise<void>;
   onRetry: (jobId: string) => Promise<void>;
   onDelete: (jobId: string) => Promise<void>;
@@ -47,6 +48,7 @@ export function DownloadQueue({
   downloads,
   stats,
   loading,
+  refreshing,
   onCancel,
   onRetry,
   onDelete,
@@ -207,10 +209,10 @@ export function DownloadQueue({
                 variant="outline"
                 size="sm"
                 onClick={onRefresh}
-                disabled={loading}
+                disabled={refreshing}
                 className="flex items-center gap-2"
               >
-                <RefreshCw className={cn('h-4 w-4', loading && 'animate-spin')} />
+                <RefreshCw className={cn('h-4 w-4', refreshing && 'animate-spin')} />
                 Refresh
               </Button>
 
@@ -286,8 +288,8 @@ export function DownloadQueue({
 
       {/* Downloads List */}
       <div className="space-y-4">
-        {loading && downloads.length === 0 ? (
-          // Loading state
+        {loading && (stats.total === undefined || stats.total === null) ? (
+          // Loading state - only show when stats haven't loaded yet
           <GlassCard className="p-12 text-center">
             <div className="flex items-center justify-center gap-3 text-white/60">
               <RefreshCw className="h-5 w-5 animate-spin" />


### PR DESCRIPTION
## Summary
Resolves the persistent loading spinner issue in the Downloads page where "Loading downloads..." would continue spinning indefinitely even after data loaded successfully.

## Problem
- Downloads page showed persistent loading spinner even with tab counts displaying (All 0, Active 0, etc.)
- Complex timing-based loading logic caused race conditions between initial load and background polling
- Background polling was incorrectly triggering loading states that should be silent

## Solution
- **Simplified loading condition**: Only show loading when `stats.total` is undefined/null
- **Added separate refresh state**: User-triggered refresh uses dedicated `refreshing` state
- **Silent background polling**: Polling updates data without affecting UI loading states
- **Proper state lifecycle**: Loading clears after initial API response, never returns

## Changes
- `useDownloads` hook: Added `refreshing` state, simplified loading logic
- `DownloadQueue` component: Updated loading condition, separate refresh spinner
- Downloads page: Wired up separate loading/refreshing states

## Testing
✅ Tested with Playwright browser automation:
- Initial load shows brief spinner, then proper empty state
- Tab counts update correctly (0 values)
- Background polling is completely silent
- Refresh button shows spinner only briefly
- No persistent loading indicators

## Security
✅ Reviewed by security-audit-specialist: **LOW RISK**
- No security vulnerabilities introduced
- Changes are client-side UI improvements only
- Maintains existing security posture

🤖 Generated with [Claude Code](https://claude.ai/code)